### PR TITLE
Fix no-opts CHOOSE

### DIFF
--- a/ggserver.py
+++ b/ggserver.py
@@ -557,7 +557,8 @@ class Connection (ConnectionBase):
     if 'opts' in msg:
       opts = msg['opts']
     else:
-      opts = list(self.members)
+      opts = [m.name for m in self.room.members]
+
     choice = random.choice(opts)
 
     omsg = Msg("CHOOSE", echo = msg.get("echo", True))


### PR DESCRIPTION
- No `opts` should choose a random player.
- Connection was attempting to create a list of `self.members`.
- Corrected to be names of `self.room.members`.
